### PR TITLE
New GPU percentage menu + added memoization to avoid recalculation on every render

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -152,6 +152,11 @@ select {
   font-weight: bold;
 }
 
+.result-standard {
+  color: var(--secondary-color);
+  font-weight: normal;
+}
+
 .section-title {
   margin-top: 0;
   margin-bottom: 1rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,9 +181,7 @@ function App() {
             </select>
           </div>
 
-
-
-          <hr style={{ margin: '1rem 0' }} />
+          <hr style={{ margin: "1rem 0" }} />
 
           <h2 className="section-title">System Configuration</h2>
 
@@ -198,7 +196,7 @@ function App() {
             </option>
           </select>
 
-          {memoryMode === 'DISCRETE_GPU' && (
+          {memoryMode === "DISCRETE_GPU" && (
             <>
               <label className="label-range">GPU VRAM (GB):</label>
               <select
@@ -243,31 +241,30 @@ function App() {
                   }
                 />
               </div>
+              <label className="label-range">
+                System Memory (GB):
+                <input
+                  className="text-input-group"
+                  type="number"
+                  min={8}
+                  max={512}
+                  step={8}
+                  value={systemMemory}
+                  onChange={(e) => handleInputChange(e, setSystemMemory)}
+                />
+              </label>
+              <div className="slider-input-group">
+                <input
+                  type="range"
+                  min={8}
+                  max={512}
+                  step={8}
+                  value={systemMemory}
+                  onChange={(e) => setSystemMemory(Number(e.target.value))}
+                />
+              </div>
             </>
           )}
-
-          <label className="label-range">
-            System Memory (GB):
-            <input
-              className="text-input-group"
-              type="number"
-              min={8}
-              max={512}
-              step={8}
-              value={systemMemory}
-              onChange={(e) => handleInputChange(e, setSystemMemory)}
-            />
-          </label>
-          <div className="slider-input-group">
-            <input
-              type="range"
-              min={8}
-              max={512}
-              step={8}
-              value={systemMemory}
-              onChange={(e) => setSystemMemory(Number(e.target.value))}
-            />
-          </div>
         </div>
 
         {/* Right Panel: Results */}
@@ -308,12 +305,13 @@ function App() {
             {recommendation.systemRamNeeded.toFixed(1)} GB
           </p>
 
-          {memoryMode === 'UNIFIED_MEMORY' && recommendation.fitsUnified && (
-            <p style={{ color: 'green' }}>✅ Fits in unified memory!</p>
+          {memoryMode === "UNIFIED_MEMORY" && recommendation.fitsUnified && (
+            <p style={{ color: "green" }}>✅ Fits in unified memory!</p>
           )}
-          {memoryMode === 'UNIFIED_MEMORY' && !recommendation.fitsUnified && (
-            <p style={{ color: 'red' }}>
-              ⚠️ Exceeds unified memory. Increase system RAM or reduce model size.
+          {memoryMode === "UNIFIED_MEMORY" && !recommendation.fitsUnified && (
+            <p style={{ color: "red" }}>
+              ⚠️ Exceeds unified memory. Increase system RAM or reduce model
+              size.
             </p>
           )}
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,10 +300,14 @@ function App() {
             </p>
           )}
 
-          <p>
-            <strong>System RAM:</strong>{" "}
-            {recommendation.systemRamNeeded.toFixed(1)} GB
-          </p>
+          {memoryMode === "UNIFIED_MEMORY" && (
+            <>
+              <p>
+                <strong>System RAM:</strong>{" "}
+                {recommendation.systemRamNeeded.toFixed(1)} GB
+              </p>
+            </>
+          )}
 
           {memoryMode === "UNIFIED_MEMORY" && recommendation.fitsUnified && (
             <p style={{ color: "green" }}>✅ Fits in unified memory!</p>

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -1,21 +1,36 @@
 import { MemoryMode, ModelQuantization, KvCacheQuantization, Recommendation } from './types';
 
+const BASE_CONTEXT_LENGTH = 2048;
+const KV_CACHE_ALPHA = 0.2; // fraction representing typical KV cache overhead
+const DISK_SIZE_OVERHEAD = 1.1; // ~10% overhead
+
 /**
  * Returns bits-based multiplier for the main model based on quantization
  */
 export const getModelQuantFactor = (q: ModelQuantization): number => {
   switch (q) {
-    case 'F32': return 4.0;
-    case 'F16': return 2.0;
-    case 'Q8': return 1.0;
-    case 'Q6': return 0.75;
-    case 'Q5': return 0.625;
-    case 'Q4': return 0.5;
-    case 'Q3': return 0.375;
-    case 'Q2': return 0.25;
-    case 'GPTQ': return 0.4;
-    case 'AWQ': return 0.35;
-    default: return 1.0;   // fallback
+    case "F32":
+      return 4.0;
+    case "F16":
+      return 2.0;
+    case "Q8":
+      return 1.0;
+    case "Q6":
+      return 0.75;
+    case "Q5":
+      return 0.625;
+    case "Q4":
+      return 0.5;
+    case "Q3":
+      return 0.375;
+    case "Q2":
+      return 0.25;
+    case "GPTQ":
+      return 0.4;
+    case "AWQ":
+      return 0.35;
+    default:
+      return 1.0; // fallback
   }
 };
 
@@ -24,12 +39,18 @@ export const getModelQuantFactor = (q: ModelQuantization): number => {
  */
 export const getKvCacheQuantFactor = (k: KvCacheQuantization): number => {
   switch (k) {
-    case 'F32': return 4.0;
-    case 'F16': return 2.0;
-    case 'Q8': return 1.0;
-    case 'Q5': return 0.625;
-    case 'Q4': return 0.5;
-    default: return 1.0;   // fallback
+    case "F32":
+      return 4.0;
+    case "F16":
+      return 2.0;
+    case "Q8":
+      return 1.0;
+    case "Q5":
+      return 0.625;
+    case "Q4":
+      return 0.5;
+    default:
+      return 1.0; // fallback
   }
 };
 
@@ -49,7 +70,7 @@ export const calculateRequiredVram = (
   const baseModelMem = params * modelFactor; // GB if 1B params
 
   // 2) Context scaling
-  let contextScale = contextLength / 2048;
+  let contextScale = contextLength / BASE_CONTEXT_LENGTH;
   if (contextScale < 1) contextScale = 1;
   const modelMem = baseModelMem * contextScale;
 
@@ -57,8 +78,7 @@ export const calculateRequiredVram = (
   let kvCacheMem = 0;
   if (useKvCache) {
     const kvFactor = getKvCacheQuantFactor(kvCacheQuant);
-    const alpha = 0.2; // fraction representing typical KV overhead
-    kvCacheMem = params * kvFactor * contextScale * alpha;
+    kvCacheMem = params * kvFactor * contextScale * KV_CACHE_ALPHA;
   }
 
   // 4) total
@@ -68,7 +88,8 @@ export const calculateRequiredVram = (
 /**
  * For unified memory, up to 75% of system RAM can be used as VRAM
  */
-export const getMaxUnifiedVram = (memGB: number): number => memGB * 0.75;
+export const getMaxUnifiedVram = (memGB: number, ramUsage: number): number =>
+  memGB * (ramUsage / 100);
 
 /**
  * Calculate the hardware recommendation based on the model and system configuration
@@ -81,7 +102,8 @@ export const calculateHardwareRecommendation = (
   kvCacheQuant: KvCacheQuantization,
   memoryMode: MemoryMode,
   systemMemory: number,
-  gpuVram: number
+  gpuVram: number,
+  ramUsage: number
 ): Recommendation => {
   const requiredVram = calculateRequiredVram(
     params,
@@ -92,11 +114,11 @@ export const calculateHardwareRecommendation = (
   );
   const recSystemMemory = systemMemory;
 
-  if (memoryMode === 'UNIFIED_MEMORY') {
-    const unifiedLimit = getMaxUnifiedVram(recSystemMemory);
+  if (memoryMode === "UNIFIED_MEMORY") {
+    const unifiedLimit = getMaxUnifiedVram(recSystemMemory, ramUsage);
     if (requiredVram <= unifiedLimit) {
       return {
-        gpuType: 'Unified memory (ex: Apple silicon, AMD Ryzen™ Al Max+ 395)',
+        gpuType: "Unified memory (ex: Apple silicon, AMD Ryzen™ Al Max 395)",
         vramNeeded: requiredVram.toFixed(1),
         fitsUnified: true,
         systemRamNeeded: recSystemMemory,
@@ -104,7 +126,7 @@ export const calculateHardwareRecommendation = (
       };
     } else {
       return {
-        gpuType: 'Unified memory (insufficient)',
+        gpuType: "Unified memory (insufficient)",
         vramNeeded: requiredVram.toFixed(1),
         fitsUnified: false,
         systemRamNeeded: recSystemMemory,
@@ -139,25 +161,49 @@ export const calculateHardwareRecommendation = (
 /**
  * Estimate on-disk model size (GB). We do NOT factor in KV here.
  */
-export const calculateOnDiskSize = (params: number, modelQuant: ModelQuantization): number => {
+export const calculateOnDiskSize = (
+  params: number,
+  modelQuant: ModelQuantization
+): number => {
   let bitsPerParam: number;
   switch (modelQuant) {
-    case 'F32': bitsPerParam = 32; break;
-    case 'F16': bitsPerParam = 16; break;
-    case 'Q8': bitsPerParam = 8; break;
-    case 'Q6': bitsPerParam = 6; break;
-    case 'Q5': bitsPerParam = 5; break;
-    case 'Q4': bitsPerParam = 4; break;
-    case 'Q3': bitsPerParam = 3; break;
-    case 'Q2': bitsPerParam = 2; break;
-    case 'GPTQ': bitsPerParam = 4; break;
-    case 'AWQ': bitsPerParam = 4; break;
-    default: bitsPerParam = 8; break;
+    case "F32":
+      bitsPerParam = 32;
+      break;
+    case "F16":
+      bitsPerParam = 16;
+      break;
+    case "Q8":
+      bitsPerParam = 8;
+      break;
+    case "Q6":
+      bitsPerParam = 6;
+      break;
+    case "Q5":
+      bitsPerParam = 5;
+      break;
+    case "Q4":
+      bitsPerParam = 4;
+      break;
+    case "Q3":
+      bitsPerParam = 3;
+      break;
+    case "Q2":
+      bitsPerParam = 2;
+      break;
+    case "GPTQ":
+      bitsPerParam = 4;
+      break;
+    case "AWQ":
+      bitsPerParam = 4;
+      break;
+    default:
+      bitsPerParam = 8;
+      break;
   }
 
   const totalBits = params * 1e9 * bitsPerParam;
   const bytes = totalBits / 8;
   const gigabytes = bytes / 1e9;
-  const overheadFactor = 1.1; // ~10% overhead
-  return gigabytes * overheadFactor;
+  return gigabytes * DISK_SIZE_OVERHEAD;
 };


### PR DESCRIPTION
I noticed that usable RAM is always capped at 75% for `Unified memory`, and thought maybe this can also be configured (still capped max at 90% to protect system). The menu pops up when user chooses `Unified memory`.

I noticed that `System Memory` also redundant with `Discrete GPU` option. So, also made it hidden with `discrete GPU` option. Same with `System RAM` part of `Hardware Requirements`. Also hidden without `Unified Memory`.

Then I added memoization for `recommendation` and `onDiskSize` to avoid recalculation on every render.

For calculations.ts, I noticed that you have some hardcoded values that could be better written in start of file (`BASE_CONTEXT_LENGTH`, `KV_CACHE_ALPHA`, and `DISK_SIZE_OVERHEAD`).

...and the rest is formatting changes (I tried my best to not overdrive with formatting changes that should be done on a separate PR to not cause trouble to eye while checking the code ;)