### PR TITLE
Fix "increment" mode bug when "no kvcache" selected

### DIFF
--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -67,16 +67,18 @@ export const calculateRequiredVram = (
   let contextMem = 0;
 
   if (inferenceMode === 'incremental') {
+    // Incremental/streaming decoding:
+    // Memory usage is primarily driven by the KV cache if enabled.
     // Start with basic context scaling for all cases
     const contextScale = Math.max(contextLength / 2048, 1);
     contextMem = baseModelMem * contextScale;
 
     // If KV cache is enabled, adjust the memory calculation
     if (useKvCache) {
-        // alphaAt2048 represents the fraction of base model memory used by the KV cache at 2048 tokens.
-        const alphaAt2048 = 0.2;
-        const kvFactor = getKvCacheQuantFactor(kvCacheQuant);
-        contextMem = baseModelMem * alphaAt2048 * contextScale * kvFactor;
+      // alphaAt2048 represents the fraction of base model memory used by the KV cache at 2048 tokens.
+      const alphaAt2048 = 0.2;
+      const kvFactor = getKvCacheQuantFactor(kvCacheQuant);
+      contextMem = baseModelMem * alphaAt2048 * contextScale * kvFactor;
     }
   } else {
     // Bulk forward pass:

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -67,17 +67,17 @@ export const calculateRequiredVram = (
   let contextMem = 0;
 
   if (inferenceMode === 'incremental') {
-    // Incremental/streaming decoding:
-    // Memory usage is primarily driven by the KV cache if enabled.
+    // Start with basic context scaling for all cases
+    const contextScale = Math.max(contextLength / 2048, 1);
+    contextMem = baseModelMem * contextScale;
+
+    // If KV cache is enabled, adjust the memory calculation
     if (useKvCache) {
-      // alphaAt2048 represents the fraction of base model memory used by the KV cache at 2048 tokens.
-      const alphaAt2048 = 0.2;
-      const kvFactor = getKvCacheQuantFactor(kvCacheQuant);
-      // Scale KV memory linearly with context length relative to 2048 tokens.
-      const kvScale = contextLength / 2048;
-      contextMem = baseModelMem * alphaAt2048 * kvScale * kvFactor;
+        // alphaAt2048 represents the fraction of base model memory used by the KV cache at 2048 tokens.
+        const alphaAt2048 = 0.2;
+        const kvFactor = getKvCacheQuantFactor(kvCacheQuant);
+        contextMem = baseModelMem * alphaAt2048 * contextScale * kvFactor;
     }
-    // When KV cache is off, minimal extra memory is required for incremental decoding.
   } else {
     // Bulk forward pass:
     // In bulk mode, the entire context is processed at once, leading to a larger memory footprint.

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -78,7 +78,7 @@ export const calculateRequiredVram = (
       // alphaAt2048 represents the fraction of base model memory used by the KV cache at 2048 tokens.
       const alphaAt2048 = 0.2;
       const kvFactor = getKvCacheQuantFactor(kvCacheQuant);
-      contextMem = baseModelMem * alphaAt2048 * contextScale * kvFactor;
+      contextMem = contextMem * alphaAt2048 * kvFactor;
     }
   } else {
     // Bulk forward pass:


### PR DESCRIPTION
When "increment" mode is selected, but "kv cache" is not, there was no "else" case for calculating the contextMem value. I refactored the anonymous function slightly to calculate the "else" case upfront by looking at your algorithm from your previous commit. 

I also added ```const contextScale = Math.max(contextLength / 2048, 1);``` because I suspect you don't want the contextScale to go below 1 in case contextLength is less than 2048, correct?

Please check this over and let me know if this looks right. Thanks.