### PR TITLE
Added 20GB option for GPU VRAM

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -243,6 +243,7 @@ function App() {
                 <option value={8}>8</option>
                 <option value={12}>12</option>
                 <option value={16}>16</option>
+                <option value={20}>20</option>
                 <option value={24}>24</option>
                 <option value={32}>32</option>
                 <option value={40}>40</option>


### PR DESCRIPTION
AMD RX 7900 XT has 20GB of VRAM. Added value for the drop-down menu options.